### PR TITLE
First commits !

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
 build/
 .DS_Store
+.vs
 
 cmake-build*
+CMakeSettings.json
 .directory
 po/POTFILES.in.test
 temp
 tmp
+cache
 master.zip
+Forms/*.cpp
+Forms/*.h

--- a/src/ooControlDialogImpl.cpp
+++ b/src/ooControlDialogImpl.cpp
@@ -512,8 +512,16 @@ void ooControlDialogImpl::OnButtonClickDeleteObservation( wxCommandEvent& event 
 {
     if (!m_Observations) return;
 
-    if (m_Observations->GetNumberRows() > 0)
-        m_Observations->DeleteRows(0);
+    
+    if (m_Observations->GetNumberRows() <= 0) return;
+
+    const int response = wxMessageBox(
+        "Warning: your last observation will be deleted. Do you want to "
+        "continue?",
+        "Delete last observation?", wxYES_NO, this);
+    if (response != wxYES) return;
+
+    m_Observations->DeleteRows(0);
 }
 
 void ooControlDialogImpl::OnButtonClickDeleteAllObservations(wxCommandEvent& event)

--- a/src/ooControlDialogImpl.cpp
+++ b/src/ooControlDialogImpl.cpp
@@ -65,7 +65,14 @@ ooControlDialogImpl::ooControlDialogImpl(wxWindow* parent)
     m_MiniPanel->SetToggleWindowButtonLabel("Minimize");
     this->Connect(wxEVT_SHOW, wxShowEventHandler(ooMiniPanel::OnShow), NULL, m_MiniPanel);
     
-    std::function<void(wxCommandEvent&)> refreshHandler = [&](wxCommandEvent& event) { m_ObservationsTable->Refresh(); event.Skip(); };
+    std::function<void(wxCommandEvent&)> refreshHandler = [&](wxCommandEvent& event)
+        {
+            m_ObservationsTable->Refresh();
+            event.Skip();
+            if (event.GetEventType() == OBSERVATION_STARTED) {
+                SetupObservationTable(1);
+            }
+        };
     m_MiniPanel->Bind(OBSERVATION_STARTED, refreshHandler);
     m_MiniPanel->Bind(OBSERVATION_STOPPED, refreshHandler);
 
@@ -281,6 +288,26 @@ void ooControlDialogImpl::CreateObservationsTable(ooObservations *observations)
 	m_fgSizerObservations->Add(m_ObservationsTable, 0, wxALL|wxEXPAND, 5);    
 }
 
+void ooControlDialogImpl::SetupObservationTable(int row_count)
+{
+  if (row_count == -1) row_count = m_Observations->GetRowsCount();
+
+  // Setup listings editors
+  const int C = m_gridProject->GetNumberCols();
+
+  for (int c = 0; c < C; ++c) {
+    const wxString field_type = m_Observations->GetColFieldTypes()[c];
+    wxArrayString items;
+    if (ooObservations::GetListing(field_type, &items)) {
+      for (int r = 0; r < row_count; ++r) {
+        wxGridCellChoiceEditor* observationFieldTypeEditor =
+            new wxGridCellChoiceEditor(items, true);
+        m_ObservationsTable->SetCellEditor(r, c, observationFieldTypeEditor);
+      }
+    }
+  }
+}
+
 void ooControlDialogImpl::RestoreBackupObservations()
 {
     if (!m_Observations) return;
@@ -290,6 +317,8 @@ void ooControlDialogImpl::RestoreBackupObservations()
     {
         wxMessageBox("Error loading observations file " + m_BackupFilename + ".", "Error", wxOK, this);
     }
+
+    SetupObservationTable();
 
     // start timer to backup observations every 30 seconds
     m_BackupTimer.Start(30000); // 30'000 ms = 30 s
@@ -506,6 +535,8 @@ void ooControlDialogImpl::OnButtonClickNewObservation( wxCommandEvent& event )
     if (!m_Observations) return;
 
     m_Observations->InsertRows(0, 1);
+
+    SetupObservationTable(1);
 }
 
 void ooControlDialogImpl::OnButtonClickDeleteObservation( wxCommandEvent& event )

--- a/src/ooControlDialogImpl.h
+++ b/src/ooControlDialogImpl.h
@@ -59,6 +59,7 @@ public:
 
 protected:
         void SetupObservationsForProject();
+        void SetupObservationTable(int row_count = -1);
 
         void OnButtonClickProjectEditUse(wxCommandEvent& event);
         void OnButtonClickProjectNew(wxCommandEvent& event);

--- a/src/ooObservations.cpp
+++ b/src/ooObservations.cpp
@@ -31,6 +31,8 @@
 
 #include "ocpn_plugin.h"
 
+std::unordered_map<wxString, wxArrayString> ooObservations::m_listings;
+
 ooObservations::ooObservations() : wxGridStringTable(0, 0), m_IsObserving(false)
 {
 }
@@ -49,7 +51,7 @@ void ooObservations::SetColSizes(const wxGridSizesInfo &sizeInfo)
     m_col_sizes = sizeInfo;
 }
 
-wxArrayString ooObservations::GetColFieldTypes() const
+const wxArrayString& ooObservations::GetColFieldTypes() const
 {
     return m_col_field_types;
 }
@@ -338,6 +340,30 @@ void ooObservations::SaveToXML(wxFile *file)
     file->Write(stream.GetString());    
 }
 
+bool ooObservations::ReadListingFromXML(const wxString& filename, wxArrayString* result) {
+  wxXmlDocument xmlDoc;
+  if (result == NULL) return false;
+  if (filename.IsEmpty() || (!xmlDoc.Load(filename)) ||
+      (xmlDoc.GetRoot()->GetName() != "listing") ||
+      (xmlDoc.GetRoot()->GetAttribute("file_version") != "1")) {
+    return false;
+  }
+
+  wxXmlNode* item = xmlDoc.GetRoot()->GetChildren();
+  while (item) {
+    int r = -1;
+    wxString label = item->GetAttribute("label");
+    if (label.length() > 0) {
+      result->Add(label);
+    }
+
+    item = item->GetNext();
+  }
+
+  return true;
+}
+
+
 bool ooObservations::ReadFromXML(wxString& filename)
 {
     wxXmlDocument xmlDoc;
@@ -392,5 +418,25 @@ wxArrayString ooObservations::GetObservationFieldTypes()
     observationFieldTypes.Add("Observation Duration");
     observationFieldTypes.Add("Mark GUID");
     observationFieldTypes.Add("Text");
+    
+    for (auto it : m_listings)
+    {
+      observationFieldTypes.Add(it.first);
+    }
+
     return observationFieldTypes;
+}
+
+void ooObservations::AddListing(const wxString& listing, const wxArrayString& items)
+{
+    m_listings[listing] = items;
+}
+
+bool ooObservations::GetListing(const wxString& listing, wxArrayString* items)
+{
+    if (m_listings.find(listing) == m_listings.end()) return false;
+    if (items == NULL) return false;
+
+    *items = m_listings.at(listing);
+    return true;
 }

--- a/src/ooObservations.h
+++ b/src/ooObservations.h
@@ -29,6 +29,7 @@
 #include <wx/file.h>
 #include <wx/grid.h>
 #include <wx/stopwatch.h>
+#include <unordered_map>
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Class ooObservations
@@ -42,7 +43,7 @@ public:
     wxGridSizesInfo GetColSizes() const;
     void SetColSizes(const wxGridSizesInfo &sizeInfo);
 
-    wxArrayString GetColFieldTypes() const;
+    const wxArrayString& GetColFieldTypes() const;
     void SetColFieldTypes(const wxArrayString &colFieldTypes);
 
     void SetPositionFix(time_t fixTime, double lat, double lon);
@@ -62,10 +63,15 @@ public:
     bool ReadFromXML(wxString& filename);
 
     static wxArrayString GetObservationFieldTypes();
+    static void AddListing(const wxString& listing, const wxArrayString& items);
+    static bool GetListing(const wxString& listing, wxArrayString* items);
+    static bool ReadListingFromXML(const wxString& filename, wxArrayString* result);
+
 
 private:
     wxGridSizesInfo m_col_sizes;
     wxArrayString m_col_field_types;
+    static std::unordered_map<wxString, wxArrayString> m_listings;
 
     time_t m_position_fix_time;
     double m_position_fix_lat;

--- a/src/openobserver_pi.cpp
+++ b/src/openobserver_pi.cpp
@@ -77,6 +77,7 @@ wxString                *g_PrivateDataDir;
 wxString                *g_pData;
 wxString                *g_SData_Locn;
 wxString                *g_pLayerDir;
+wxString                *g_pListingDir;
 
 wxString                *g_tplocale;
 void                    *g_ppimgr;
@@ -159,6 +160,23 @@ openobserver_pi::openobserver_pi(void *ppimgr)
     if (!wxDir::Exists(*g_pLayerDir))
         wxMkdir(*g_pLayerDir);
 
+    g_pListingDir = new wxString(*g_PrivateDataDir);
+    g_pListingDir->Append(wxT("Listings"));
+    appendOSDirSlash(g_pListingDir);
+    if (!wxDir::Exists(*g_pListingDir))
+        wxMkdir(*g_pListingDir);
+
+    wxArrayString allListings;
+    wxDir::GetAllFiles(*g_pListingDir, &allListings);
+    for (auto f : allListings)
+    {
+        wxArrayString items;
+        if (ooObservations::ReadListingFromXML(f, &items))
+        {
+            wxString filename = f.AfterLast('/').AfterLast('\\').BeforeLast('.');
+            ooObservations::AddListing(filename, items);
+        }
+    }
     m_ptpicons = new tpicons();
 
     delete l_pDir;
@@ -177,6 +195,9 @@ openobserver_pi::~openobserver_pi()
 
     delete g_pLayerDir;
     g_pLayerDir = NULL;
+
+    delete g_pListingDir;
+    g_pListingDir = NULL;
 }
 
 int openobserver_pi::Init(void)


### PR DESCRIPTION
Alex,

I send this pull-request to open the discussion with you about the plugin.

- first commit (de7d48e) is some files I had to add to .gitignore to have a clean repo building under Windows VisualStudio
- second commit (75c8aaa) was me trying to make the simplest change :) justing adding a confirmation dialog when deleting an observation
- third one (0ceea25) is the biggest one, with one full (?) feature: we can now have a configurable field-type that we can later edit in observations with a dropdown. The 'configurable' part is a .xml file that must be put in ProgramData\opencpn\plugins\openobserver_pi\Listings. Typically, we can use this feature to have a custom dictionary of species.
[Species.xml](https://github.com/user-attachments/files/24866303/Species.xml)

Tell me what you think about it, and do not hesitate to be blunt and picky about any part of it. I did not meant all of it to be necessarily included upstream, I was also trying stuff just to get used with the environment/SDK/opencpn/plugin, so no worries if we must throw away some stuff. Maybe you'd also like for me to split this pull request in smaller parts ?