### PR TITLE
Listing icons bugfix + OpenCPN 5.14.0 crashfix

### DIFF
--- a/src/ooControlDialogImpl.cpp
+++ b/src/ooControlDialogImpl.cpp
@@ -90,13 +90,14 @@ ooControlDialogImpl::ooControlDialogImpl(wxWindow* parent)
     RefreshListings();
     OnProjectGridSelectionChange();
 
-    m_listMarkIcons->Append(GetIconNameArray());
     m_currentObservationsIndex = 0;
 
     // bind backup timer (started in RestoreBackupObservations)
     m_BackupTimer.Bind(wxEVT_TIMER, &ooControlDialogImpl::OnBackupTimer, this, m_BackupTimer.GetId());
     // start timer to backup observations every 30 seconds
     m_BackupTimer.Start(30000);  // 30'000 ms = 30 s
+
+    this->Connect(wxEVT_SHOW, wxShowEventHandler(ooControlDialogImpl::OnShow), NULL, this);
 }
 
 ooControlDialogImpl::~ooControlDialogImpl()
@@ -116,12 +117,26 @@ ooControlDialogImpl::~ooControlDialogImpl()
                                NULL, this);
     }
     this->Disconnect(wxEVT_SHOW, wxShowEventHandler(ooMiniPanel::OnShow), NULL, m_MiniPanel);
+    this->Disconnect(wxEVT_SHOW, wxShowEventHandler(ooControlDialogImpl::OnShow), NULL, this);
 
     m_BackupTimer.Stop();
 
     if (!m_Observations) return;
 
     SaveObservations(GetBackupFilename(m_currentObservationsIndex));
+}
+
+void ooControlDialogImpl::OnShow(wxShowEvent& event)
+{
+    // !!! Work-around !!!
+    // Since OpenCPN 5.14.0, calling GetIconNameArray() during plugin initialization crashes
+    // so we'll do it here as a "post-initialization" step.
+    if (m_Observations != NULL) {
+        m_listMarkIcons->Set(GetIconNameArray());
+        m_listMarkIcons->SetSelection(m_listMarkIcons->FindString(
+            m_Observations->GetProject().GetMarkIcon())
+        );
+    }
 }
 
 void ooControlDialogImpl::NewProject()

--- a/src/ooControlDialogImpl.h
+++ b/src/ooControlDialogImpl.h
@@ -93,6 +93,7 @@ public:
         void OnProjectGridCellSelect(wxGridEvent& event);
         void OnProjectGridRangeSelect(wxGridRangeSelectEvent& event);
         void OnObservationsGridCellChange(wxGridEvent& event);
+        void OnShow(wxShowEvent& event);
 
       private:
         void OnBackupTimer(wxTimerEvent& event);

--- a/src/ooObservations.cpp
+++ b/src/ooObservations.cpp
@@ -161,8 +161,7 @@ void ooProject::OnFieldTypeChanged()
 }
 
 std::unordered_map<wxString, wxArrayString> ooObservations::m_listings;
-wxArrayString ooObservations::m_icons;
-wxString ooObservations::m_iconsListing;
+std::unordered_map<wxString, wxArrayString> ooObservations::m_listingsIcons;
 
 ooObservations::ooObservations() : wxGridStringTable(0, 0), m_IsObserving(false)
 {
@@ -546,6 +545,7 @@ void ooObservations::AddMarks(int targetRow)
     int nameCol = -1;
     int descriptionCol = -1;
     int iconCol = -1;
+    wxString iconFieldType;
     const int C = m_project.GetColCount();
 
     for (int c=0; c<C; ++c)
@@ -563,8 +563,9 @@ void ooObservations::AddMarks(int targetRow)
             if (latCol < 0) latCol = c;
         } else if (field_type.IsSameAs("Start Longitude")) {
             if (lonCol < 0) lonCol = c;
-        } else if (field_type.IsSameAs(m_iconsListing)) {
+        } else if (m_listingsIcons.find(field_type) != m_listingsIcons.end()) {
             if (iconCol < 0) iconCol = c;
+            iconFieldType = field_type;
         } else if (field_type.IsSameAs("Text")) {
             // use first text column as name and second as description
             if (nameCol < 0) nameCol = c;
@@ -605,8 +606,8 @@ void ooObservations::AddMarks(int targetRow)
             wxString icon;
             if (iconCol != -1) {
                 wxString iconValue = GetValue(r, iconCol);
-                int iconIndex = m_listings[m_iconsListing].Index(iconValue);
-                if (iconIndex != wxNOT_FOUND) icon = m_icons[iconIndex];
+                int iconIndex = m_listings[iconFieldType].Index(iconValue);
+                if (iconIndex != wxNOT_FOUND) icon = m_listingsIcons[iconFieldType][iconIndex];
             }
             if (icon.IsEmpty()) icon = m_project.GetMarkIcon();
             
@@ -1071,8 +1072,7 @@ wxArrayString ooObservations::GetObservationFieldTypes()
 void ooObservations::ClearListings()
 {
     m_listings.clear();
-    m_icons.clear();
-    m_iconsListing.clear();
+    m_listingsIcons.clear();
 }
 
 void ooObservations::AddListing(const wxString& listing, const wxArrayString& items)
@@ -1102,10 +1102,9 @@ wxArrayString ooObservations::GetListingKeys()
     return res;
 }
 
-void ooObservations::SetIcons(const wxString& listing, const wxArrayString& icons)
+void ooObservations::AddIcons(const wxString& listing, const wxArrayString& icons)
 {
-    m_icons = icons;
-    m_iconsListing = listing;
+    m_listingsIcons[listing] = icons;
 }
 
 void ooObservations::SetNMEAFields(const std::vector<NMEAField>& fields)

--- a/src/ooObservations.cpp
+++ b/src/ooObservations.cpp
@@ -38,6 +38,8 @@
 #include "ocpn_plugin.h"
 #include <openobserver_pi.h>
 
+extern openobserver_pi* g_openobserver_pi;
+
 void ComputeTrueWind(double sog, double cog, double apparentWindSpeed,
                      double apparentWindAngle, double& trueWindSpeed,
                      double& trueWindDirection);
@@ -667,6 +669,13 @@ void ooObservations::DeleteMarks(int targetRow)
 
 int ooObservations::UpdateObservationsFromMarks()
 {
+    // !!! Work-around !!!
+    // Since OpenCPN 5.14.0, calling GetSingleWaypoint() during plugin
+    // initialization crashes so we'll skip this step if plugin initizalization is not done.
+    // (which does not matter, because there are no usecases where this function has anything
+    // to do during initialization)
+    if (!g_openobserver_pi->IsLateInitDone()) return 0; 
+
     int res = 0;
     const int R = GetRowsCount();
     const int markCol = GetProject().GetMarkCol();

--- a/src/ooObservations.h
+++ b/src/ooObservations.h
@@ -163,7 +163,7 @@ public:
                             ooProject& project,
                             wxXmlDocument& xmlDoc, wxXmlNode*& root,
                             const ooProject& defaultProject);
-    static void SetIcons(const wxString& listing, const wxArrayString& icons);
+    static void AddIcons(const wxString& listing, const wxArrayString& icons);
     static void SetNMEAFields(const std::vector<NMEAField>& fields);
     static const std::vector<NMEAField>& GetNMEAFields();
 
@@ -175,8 +175,7 @@ public:
 private:
     ooProject m_project;
     static std::unordered_map<wxString, wxArrayString> m_listings;
-    static wxArrayString m_icons;
-    static wxString m_iconsListing;
+    static std::unordered_map<wxString, wxArrayString> m_listingsIcons;
     static std::vector<NMEAField> m_nmeaFields;
 
     time_t m_position_fix_time;

--- a/src/openobserver_pi.cpp
+++ b/src/openobserver_pi.cpp
@@ -682,7 +682,7 @@ void openobserver_pi::RefreshListings()
         if (ooObservations::ReadListingFromXML(f, items, icons)) {
             wxString filename = wxFileName(f).GetName();
             ooObservations::AddListing(filename, items);
-            if (icons.GetCount() > 0) ooObservations::SetIcons(filename, icons);
+            if (icons.GetCount() > 0) ooObservations::AddIcons(filename, icons);
         }
     }
 }

--- a/src/openobserver_pi.cpp
+++ b/src/openobserver_pi.cpp
@@ -531,6 +531,11 @@ void openobserver_pi::ToggleWindow()
     }
 }
 
+bool openobserver_pi::IsLateInitDone() const
+{
+    return m_bReadyForRequests;
+}
+
 void openobserver_pi::SaveConfig()
 {
     #ifndef __WXMSW__

--- a/src/openobserver_pi.h
+++ b/src/openobserver_pi.h
@@ -190,6 +190,7 @@ public:
 
     void ToggleToolbarIcon();
     void ToggleWindow();
+    bool IsLateInitDone() const;
 
     ooObservations *m_ooObservations;
 


### PR DESCRIPTION
Two commits here:
1. Listing icons bugfix: declaring icons in various Listings was not working very well ; it only worked if you only had 1 Listing declaring icons, because that was the first useful and simple case I wanted to implement. Now that this feature is used more extensively, here's a more robust implementation.
2. OpenCPN 5.14.0 crashfix: at least on Win32 MSVC, some opencpn_plugin API calls now crashes in OpenCPN latest version 5.14.0 (namely, GetIconNameArray and GetSingleWaypoint) when done during plugin initialization. I had to tweak the code to skip these calls/do them later.